### PR TITLE
Feature/search input

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import { styles } from './index';
 
 export default class Option extends Component {
 
@@ -10,6 +11,7 @@ export default class Option extends Component {
     prefix: PropTypes.string,
     label: PropTypes.string,
     value: PropTypes.string,
+    isFocus: PropTypes.bool,
   }
 
   handleClickOption = (e) => {
@@ -17,10 +19,17 @@ export default class Option extends Component {
   }
 
   render() {
-    const { prefix, label } = this.props;
+    const { prefix, label, isFocus } = this.props;
+
+    const style = {
+      ...styles.option,
+      ...isFocus && styles.optionWithFocus
+    };
+
     return (
       <div
         className={`${prefix}-option`}
+        style={style}
         onClick={this.handleClickOption}
       >{label}</div>
     );

--- a/src/Option.js
+++ b/src/Option.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { styles } from './index';
+import { PREFIX, styles } from './index';
 
 export default class Option extends Component {
 
@@ -8,7 +8,6 @@ export default class Option extends Component {
       section: PropTypes.number,
       row: PropTypes.number,
     }),
-    prefix: PropTypes.string,
     label: PropTypes.string,
     value: PropTypes.string,
     isFocus: PropTypes.bool,
@@ -19,7 +18,7 @@ export default class Option extends Component {
   }
 
   render() {
-    const { prefix, label, isFocus } = this.props;
+    const { label, isFocus } = this.props;
 
     const style = {
       ...styles.option,
@@ -28,7 +27,7 @@ export default class Option extends Component {
 
     return (
       <div
-        className={`${prefix}-option`}
+        className={`${PREFIX}-option`}
         style={style}
         onClick={this.handleClickOption}
       >{label}</div>

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import { styles } from './index';
 
 export default class OptionGroup extends Component {
 
@@ -14,9 +15,11 @@ export default class OptionGroup extends Component {
 
   render() {
     const { prefix, label } = this.props;
+    
     return (
       <div
         className={`${prefix}-option`}
+        style={styles.optionGroup}
       >
         <span>{label}</span>
         {this.props.children}

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { styles } from './index';
+import { PREFIX, styles } from './index';
 
 export default class OptionGroup extends Component {
 
@@ -8,20 +8,19 @@ export default class OptionGroup extends Component {
       section: PropTypes.number,
       row: PropTypes.number,
     }),
-    prefix: PropTypes.string,
     label: PropTypes.string,
     value: PropTypes.string,
   }
 
   render() {
-    const { prefix, label } = this.props;
-    
+    const { label } = this.props;
+
     return (
       <div
-        className={`${prefix}-option`}
+        className={`${PREFIX}-option`}
         style={styles.optionGroup}
       >
-        <span>{label}</span>
+        <span style={styles.optionGroupLabel}>{label}</span>
         {this.props.children}
       </div>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,9 @@ import Option from './Option';
 
 // Utils
 import isOptionGroup from './utils/isOptionGroup';
+import getOptionValue from './utils/getOptionValue';
 
-const prefix = 'rselectr';
+export const PREFIX = 'rselectr';
 
 export const styles = {
   container: {
@@ -21,22 +22,10 @@ export const styles = {
     borderRadius: 4,
     padding: '6px 12px',
   },
-  searchInputContainer: {
-    borderBottom: '1px solid #ccc',
-  },
-  searchInput: {
-    width: '100%',
-    padding: '6px 12px',
-    borderRadius: 2,
-    outline: 'none',
-    border: '1px solid #ececec',
-    boxShadow: 'none',
-  },
-  searchInputHidden: {
-    display: 'none',
-  },
   menu: {
-    padding: 8,
+    paddingTop: 50,
+    maxHeight: 300,
+    overflow: 'scroll',
     border: '1px solid #ececec',
     borderRadius: 4,
     position: 'absolute',
@@ -44,20 +33,44 @@ export const styles = {
     background: '#fff',
     width: '100%',
   },
-  option: {
+  searchInputContainer: {
     padding: '6px 12px',
+    borderBottom: '1px solid #ececec',
+    position: 'absolute',
+    width: '100%',
+    top: 0,
+    left: 0,
+  },
+  searchInput: {
+    width: '100%',
+    padding: '6px 12px',
+    borderRadius: 2,
+    outline: 'none',
+    border: '1px solid #ececec',
+    WebkitBoxShadow: 'none',
+    boxShadow: 'none',
+  },
+  searchInputHidden: {
+    display: 'none',
+  },
+  option: {
+    padding: '8px 12px',
   },
   optionWithFocus: {
     background: '#5897fb',
+    color: '#fff',
   },
   optionGroup: {
     padding: '6px 12px',
+  },
+  optionGroupLabel: {
+    fontWeight: 'bold',
   }
 }
 
 class Select extends Component {
 
-  static displayName = prefix;
+  static displayName = PREFIX;
 
   static propTypes = {
     // Options
@@ -105,13 +118,19 @@ class Select extends Component {
   /* End of Detect click Outside */
 
 
-  handleClickOption = (value) => {
+  handleSelectOption = (value) => {
 
     this.setState({
       isOpen: false,
     });
 
     this.props.onChange(value);
+  }
+
+  handleSelectOptionAtIndex = (index) => {
+    const option = this.props.options[index];
+    this.handleSelectOption(getOptionValue(option));
+
   }
 
   handleOpenMenu = () => {
@@ -127,8 +146,7 @@ class Select extends Component {
   }
 
   handleKeyDown = (event) => {
-    console.log('handleKeyDown', event.keyCode);
-		if (this.props.disabled) return;
+    if (this.props.disabled) return;
 
 		if (typeof this.props.onInputKeyDown === 'function') {
 			this.props.onInputKeyDown(event);
@@ -141,10 +159,21 @@ class Select extends Component {
 
 			case 38: // up
 				this.focusAtOption(this.state.focusAtIndex - 1);
-			break;
+			  break;
 			case 40: // down
 				this.focusAtOption(this.state.focusAtIndex + 1);
-			break;
+			  break;
+      case 13: // enter
+				if (!this.state.isOpen) return;
+				event.stopPropagation();
+				this.handleSelectOptionAtIndex(this.state.focusAtIndex);
+			  break;
+			case 27: // escape
+				if (this.state.isOpen) {
+					this.handleCloseMenu();
+					event.stopPropagation();
+				}
+			  break;
 			default: return;
 		}
 		event.preventDefault();
@@ -157,7 +186,7 @@ class Select extends Component {
     else _targetIndex = toIndex;
 
     this.setState({
-      focusAtIndex: targetIndex,
+      focusAtIndex: _targetIndex,
     });
   }
 
@@ -182,7 +211,7 @@ class Select extends Component {
 
   renderSearchInput = () => {
     return (
-      <div className={`${prefix}-searchInput-wrapper`} style={styles.searchInputContainer}>
+      <div className={`${PREFIX}-searchInput-wrapper`} style={styles.searchInputContainer}>
         <input
           type="text"
           autoFocus
@@ -219,10 +248,9 @@ class Select extends Component {
         key={`option-${_value}-${index}`}
         isFocus={focusAtIndex === index}
         index={index}
-        prefix={prefix}
         label={_label}
         value={_value}
-        onSelect={this.handleClickOption}
+        onSelect={this.handleSelectOption}
       />
     );
   }
@@ -234,21 +262,25 @@ class Select extends Component {
 
     return (
       <div
-        className={`${prefix}-container`}
+        className={`${PREFIX}-container`}
         ref={c => this.component = c}
         style={styles.container}
       >
         <div
-          className={`${prefix}-control`}
+          className={`${PREFIX}-control`}
           style={styles.control}
-          onKeyDown={this.handleKeyDown}
-					onMouseDown={this.handleMouseDown}
+          tabIndex={0}
+          onMouseDown={this.handleMouseDown}
         >
           {value || placeholder}
         </div>
         {
           isOpen &&
-            <div className={`${prefix}-menu`} style={styles.menu}>
+            <div
+              className={`${PREFIX}-menu`}
+              style={styles.menu}
+              onKeyDown={this.handleKeyDown}
+  					>
               { this.renderSearchInput() }
               { isOptionGroup(options) ? this.renderOptionGroups(options) : this.renderOptions(options) }
             </div>

--- a/src/utils/getIndexedOptions.js
+++ b/src/utils/getIndexedOptions.js
@@ -1,0 +1,17 @@
+/*
+ * Convert options and optgroup into one array with indexed
+ * for handling when using arrow keyboard up / down to navigate through option.
+ */
+import _ from 'lodash';
+import isOptionGroup from './isOptionGroup';
+
+const getIndexedOptions = (options) => {
+  // If normal options, return them;
+  if (!isOptionGroup(options)) return options;
+
+  // If OptionGroup
+  // Extract optionGroup.options from each optionGroup, and then flatten them into single array.
+  return _.flatten(_.map(options, optionGroup => optionGroup.options));
+};
+
+export default getIndexedOptions;

--- a/src/utils/getOptionValue.js
+++ b/src/utils/getOptionValue.js
@@ -1,0 +1,7 @@
+// Extract string value from either Objet or String
+// { value: '', label: ''} or 'value'
+import _ from 'lodash';
+
+const getOptionValue = option => _.get(option, 'value', option);
+
+export default getOptionValue;

--- a/src/utils/isOptionGroup.js
+++ b/src/utils/isOptionGroup.js
@@ -1,0 +1,10 @@
+import _ from 'lodash';
+
+const isOptionGroup = (options) => {
+  if (_.every(options, option => option.options !== undefined)) {
+    return true;
+  }
+  return false;
+};
+
+export default isOptionGroup;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,9 +1,9 @@
 const expect = require('chai').expect;
-const BetterImg = require('./index');
+const Select = require('../src/index');
 
-describe('BetterImg', function() {
-  describe('all', function() {
-    it('should be an array of value|label', function(){
+describe('Select', function() {
+  describe('temp', function() {
+    it('true should be true', function(){
       expect(true).to.equal(true);
     });
   });


### PR DESCRIPTION
# Changes a lot

**General**
- Temporary style for Component (request for GAMO to re-implement the real thing)
- Change how to include PREFIX in each component from using Props to import 
- Fix bug that click outside only look for body, changed to document

**Utils**
- Add new utils 'isOptionGroup' to check if props.options is plain options or optionGroups
- Add new utils 'getOptionValue' to extract string value from option (in both { value: '', label: ''} and 'value' only type)
- (In progress) Add new utils 'getIndexedOptions', to flatten optionGroups options into one single array (for arrow up/down navigation)

**Feature**
- handleKeyDown
  - Can use arrow keyboard to focus through options (still need to fix for optgroup)
  - Can press enter to select focused option