### PR TITLE
feat(option): detect mouse/touch event and behave properly

### DIFF
--- a/example/containers/App.js
+++ b/example/containers/App.js
@@ -4,6 +4,7 @@ import '../../src/scss/react-selectr.scss';
 import _ from 'lodash';
 
 import countries from './countries';
+import dotaHeroes from './data/dota-heroes';
 
 const countriesOptions = _.map(countries, item => {
   return {
@@ -48,10 +49,10 @@ export default class App extends Component {
         />
 
 
-        <h2>OptGroup</h2>
+      <h2>OptGroup (Dota2 Heroes)</h2>
         <Select
           value={value2}
-          options={countriesOptions}
+          options={dotaHeroes}
           onChange={value => this.handleChange('value2', value)}
         />
 
@@ -68,6 +69,13 @@ export default class App extends Component {
             { value: 'T', label: 'Tom' },
           ]}
           onChange={value => this.handleChange('valueMultiple', value)}
+        />
+
+      <h2>Large DataSet (Countries)</h2>
+        <Select
+          value={value2}
+          options={countriesOptions}
+          onChange={value => this.handleChange('value2', value)}
         />
 
       </div>

--- a/example/containers/data/dota-heroes.js
+++ b/example/containers/data/dota-heroes.js
@@ -1,0 +1,65 @@
+const heroes = [
+  {
+    "label": "Strength",
+    "options": [
+      { value: "axe", label: "Axe" },
+      { value: "earth_shaker", label: "Earth Shaker" },
+      { value: "pudge", label: "Pudge" },
+      { value: "sand_king", label: "Sand King" },
+      { value: "sven", label: "Sven" },
+      { value: "tiny", label: "Tiny" },
+      { value: "kunkka", label: "Kunkka" },
+      { value: "slardar", label: "Slardar" },
+      { value: "tidehunter", label: "Tidehunter" },
+      { value: "beastmaster", label: "Beastmaster" },
+      { value: "skeleton_king", label: "Skeleton King" },
+    ]
+  },
+  {
+    "label": "Agility",
+    "options": [
+      { value: "antimage", label: "Anti-Mage" },
+      { value: "bloodseeker", label: "Bloodseeker" },
+      { value: "drow_ranger", label: "Drow Ranger" },
+      { value: "juggernaut", label: "Juggernaut" },
+      { value: "mirana", label: "Mirana" },
+      { value: "shadow_fiend", label: "Shadow Fiend" },
+      { value: "morphling", label: "Morphling" },
+      { value: "phantom_lancer", label: "Phantom Lancer" },
+      { value: "razor", label: "Razor" },
+      { value: "vengeful_spirit", label: "Vengeful Spirit" },
+      { value: "windranger", label: "Windranger" },
+      { value: "riki", label: "Riki" },
+      { value: "sniper", label: "Sniper" },
+      { value: "venomancer", label: "Venomancer" },
+      { value: "faceless_void", label: "Faceless Void" },
+      { value: "phantom_assassin", label: "Phantom Assassin" },
+      { value: "templar_assassin", label: "Templar Assassin" },
+      { value: "viper", label: "Viper" },
+      { value: "luna", label: "Luna" },
+    ]
+  },
+  {
+    "label": "Inteligent",
+    "options": [
+      { value: "bane", label: "Bane" },
+      { value: "crystal_maiden", label: "Crystal Maiden" },
+      { value: "puck", label: "Puck" },
+      { value: "storm_spirit", label: "Storm Spirit" },
+      { value: "zeus", label: "Zeus" },
+      { value: "lina", label: "Lina" },
+      { value: "lich", label: "Lich" },
+      { value: "lion", label: "Lion" },
+      { value: "witch_doctor", label: "Witch Doctor" },
+      { value: "enigma", label: "Enigma" },
+      { value: "tinker", label: "Tinker" },
+      { value: "necrophos", label: "Necrophos" },
+      { value: "warlock", label: "Warlock" },
+      { value: "queen_of_pain", label: "Queen of pain" },
+      { value: "death_phophet", label: "Death Phophet" },
+      { value: "pugna", label: "Pugna" },
+    ]
+  },
+];
+
+export default heroes;

--- a/src/Option.js
+++ b/src/Option.js
@@ -5,16 +5,39 @@ import { pureRender } from './utils';
 class Option extends Component {
 
   static propTypes = {
-    indexPath: PropTypes.shape({
-      section: PropTypes.number,
-      row: PropTypes.number,
-    }),
+    index: PropTypes.number,
     label: PropTypes.string,
     value: PropTypes.string,
     isFocus: PropTypes.bool,
+
+    onFocus: PropTypes.func,
   }
 
-  handleClickOption = (e) => {
+  // Do focus option when mouse enter
+  handleMouseEnter = (event) => {
+    this.props.onFocus(this.props.index);
+  }
+
+  // MouseDown for mouse & TouchStart for touch devices
+  // set dragging to false, back to normal.
+  handleMouseDown = (e) => { this.dragging = false; this.pressing = true; }
+  handleTouchStart = (e) => { this.handleMouseDown(e.touches[0]); }
+
+  // MouseMove for mouse & TouchMove for touch devices
+  // If start moving while pressing, set dragging = true;
+  handleMouseMove = (e) => { if (this.pressing) { this.dragging = true; } }
+  handleTouchMove = (e) => { this.handleMouseMove(e.touches[0]); }
+
+  // MouseUp for mouse & TouchEnd for touch devices
+  // If mouseUp/TouchEnd if user was draggin then not fire handleSelectOption;
+  handleMouseUp = (e) => {
+    this.pressing = false;
+    if(this.dragging) return;
+    this.handleSelectOption(e);
+  }
+  handleTouchEnd = (e) => { this.handleMouseUp(e); }
+
+  handleSelectOption = (e) => {
     this.props.onSelect(this.props.value);
   }
 
@@ -24,7 +47,14 @@ class Option extends Component {
     return (
       <div
         className={`${PREFIX}-option ${isFocus && 'isFocus'}`}
-        onClick={this.handleClickOption}
+        role="option"
+        onMouseEnter={this.handleMouseEnter}
+        onMouseDown={this.handleMouseDown}
+        onTouchStart={this.handleTouchStart}
+        onMouseMove={this.handleMouseMove}
+        onTouchMove={this.handleTouchMove}
+        onMouseUp={this.handleMouseUp}
+        onTouchEnd={this.handleTouchEnd}
       >{label}</div>
     );
   }

--- a/src/Option.js
+++ b/src/Option.js
@@ -33,9 +33,16 @@ class Option extends Component {
   handleMouseUp = (e) => {
     this.pressing = false;
     if(this.dragging) return;
+
+    // TODO: Not sure why, but this prevent double selectOption from touch devices
+    e.preventDefault();
+		e.stopPropagation();
+
     this.handleSelectOption(e);
   }
-  handleTouchEnd = (e) => { this.handleMouseUp(e); }
+  handleTouchEnd = (e) => {
+    this.handleMouseUp(e);
+  }
 
   handleSelectOption = (e) => {
     this.props.onSelect(this.props.value);

--- a/src/Option.js
+++ b/src/Option.js
@@ -11,6 +11,7 @@ class Option extends Component {
     isFocus: PropTypes.bool,
 
     onFocus: PropTypes.func,
+    onSelect: PropTypes.func,
   }
 
   // Do focus option when mouse enter

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -5,12 +5,7 @@ import { pureRender } from './utils';
 class OptionGroup extends Component {
 
   static propTypes = {
-    indexPath: PropTypes.shape({
-      section: PropTypes.number,
-      row: PropTypes.number,
-    }),
     label: PropTypes.string,
-    value: PropTypes.string,
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,6 @@ class Select extends Component {
 	}
 
   focusAtOption = (toIndex) => {
-    console.log('focusAtOption', toIndex);
     let _targetIndex;
     if (toIndex < 0) _targetIndex = 0;
     else if (toIndex > this.props.options.length - 1) _targetIndex = this.props.options.length - 1;

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,6 @@ class Select extends Component {
   /* End of Detect click Outside */
 
   handleSelectOption = (currentValue) => {
-
     const {
       multiple,
       options,

--- a/src/index.js
+++ b/src/index.js
@@ -52,8 +52,6 @@ class Select extends Component {
     })),
     groups: PropTypes.arrayOf(PropTypes.string),
     placeholder: PropTypes.string,
-    openOnFocus: PropTypes.bool,          // always open options menu on focus
-    openAfterFocus: PropTypes.bool,
 
     // Events
     filterOption: PropTypes.func,         // function to filer an option
@@ -68,15 +66,11 @@ class Select extends Component {
   static defaultProps = {
     disabled: false,
     searchable: true,
-    openOnFocus: true,
-    openAfterFocus: false,
     placeholder: 'Select...',
   }
 
   state = {
     isOpen: false,
-    isFocused: false,
-    isPseudoFocused: false,
     focusAtIndex: 0, // indexToFocus
   }
 
@@ -122,9 +116,7 @@ class Select extends Component {
       onChange(_value);
 
       /* Close options */
-      this.setState({
-        isOpen: false,
-      });
+      this.handleCloseMenu();
 
     }
   }
@@ -240,19 +232,6 @@ class Select extends Component {
     );
   }
 
-  // renderOptionGroups = (options) => {
-  //   return _map(options, (optgroup, groupIndex) => this.renderOptionGroup(optgroup, groupIndex));
-  // }
-  //
-  // renderOptionGroup = (optgroup, groupIndex) => {
-  //   const { options, label } = optgroup;
-  //   return (
-  //     <OptionGroup key={`optgroup-${label}-${groupIndex}`} label={label}>
-  //       {this.renderOptions(options)}
-  //     </OptionGroup>
-  //   );
-  // }
-
   renderOptions = (groups, options) => {
     return _map(groups, (label, groupIndex) => {
       const groupOptions = _.filter(options, option => option.groupIndex === groupIndex);
@@ -261,8 +240,7 @@ class Select extends Component {
           { _map(groupOptions, option => this.renderOption(option)) }
         </OptionGroup>
       );
-    })
-    // return _map(options, (option, index) => this.renderOption(option, index));
+    });
   }
 
   renderOption = (option) => {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import _pick from 'lodash/pick';
 import _map from 'lodash/map';
 import _find from 'lodash/find';
 import _get from 'lodash/get';
+import _filter from 'lodash/filter';
 
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
@@ -234,7 +235,7 @@ class Select extends Component {
 
   renderOptions = (groups, options) => {
     return _map(groups, (label, groupIndex) => {
-      const groupOptions = _.filter(options, option => option.groupIndex === groupIndex);
+      const groupOptions = _filter(options, option => option.groupIndex === groupIndex);
       return (
         <OptionGroup key={`optgroup-${label}-${groupIndex}`} label={label}>
           { _map(groupOptions, option => this.renderOption(option)) }

--- a/src/index.js
+++ b/src/index.js
@@ -182,6 +182,7 @@ class Select extends Component {
 	}
 
   focusAtOption = (toIndex) => {
+    console.log('focusAtOption', toIndex);
     let _targetIndex;
     if (toIndex < 0) _targetIndex = 0;
     else if (toIndex > this.props.options.length - 1) _targetIndex = this.props.options.length - 1;

--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,9 @@ class Select extends Component {
         index={index}
         label={_label}
         value={_value}
+        onFocus={this.focusAtOption}
         onSelect={this.handleSelectOption}
+        on
       />
     );
   }

--- a/src/scss/react-selectr.scss
+++ b/src/scss/react-selectr.scss
@@ -67,6 +67,13 @@ $orange: #f17e39;
   &-option{
     padding: 8px 12px;
     cursor: pointer;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    
     &.isFocus{
       background-color: rgba($orange, 0.1);
     }

--- a/src/utils/mapOptions.js
+++ b/src/utils/mapOptions.js
@@ -18,9 +18,9 @@ const mapOptions = (propOptions) => {
   }
 
   // Not Option Group
-  return _map(propOptions, (opt) => {
-    if (_isString(opt)) return { label: opt, value: opt, groupIndex: 0 };
-    return { ...opt, groupIndex: 0 };
+  return _map(propOptions, (opt, index) => {
+    if (_isString(opt)) return { label: opt, value: opt, optionIndex: index, groupIndex: 0 };
+    return { ...opt, optionIndex: index, groupIndex: 0 };
   });
 };
 


### PR DESCRIPTION
** Feature **
- now option will focus onMouseEnter
- bind mousedown / touchstart event for PC and touch devices
- if user drag options (scrolling in mobile device) it won't fire selectOption event
- add css to disable text-selection in option

** Other **
- Add another demo (dota-heroes) for OptGroup 
- Move countries demo to "Large Dataset" topic